### PR TITLE
rm extra test in base test contract

### DIFF
--- a/test/TestBase.sol
+++ b/test/TestBase.sol
@@ -11,8 +11,4 @@ contract TestBase is Test, TestExt {
         string memory rpcUrl = vm.envOr("RPC_URL", DEFAULT_RPC_URL);
         vm.createSelectFork(rpcUrl);
     }
-
-    function test_base() public pure {
-        assertEq(uint256(1), 1);
-    }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the `test/TestBase.sol` file by removing a test function.

### Detailed summary
- Removed the function `test_base()` which was a public pure function asserting that `uint256(1)` equals `1`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->