### PR TITLE
add skip warning on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,4 +42,4 @@ jobs:
         run: |
           forge soldeer login --email "$SOLDEER_EMAIL" --password "$SOLDEER_PASSWORD"
           VERSION=`echo ${{ github.ref_name }} | sed 's/v//'`
-          forge soldeer push absmate~$VERSION
+          forge soldeer push --skip-warnings absmate~$VERSION


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the GitHub Actions workflow for releasing by modifying the command used to push to `soldeer`. It adds a flag to skip warnings during the push operation.

### Detailed summary
- Changed the command from `forge soldeer push absmate~$VERSION` to `forge soldeer push --skip-warnings absmate~$VERSION`, adding the `--skip-warnings` flag to suppress warning messages during the push.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->